### PR TITLE
#1: Update chips_sold plot

### DIFF
--- a/analysis/log/make.log
+++ b/analysis/log/make.log
@@ -1,12 +1,10 @@
 --------------------------------------------------------------------------------
-Makelog started: 2023-10-22 16:17:49
+Makelog started: 2023-10-23 14:05:47
 Working directory: /Users/lawrencechen/Desktop/gentzkow/analysis
 --------------------------------------------------------------------------------
 Input links successfully created!
 External links successfully created!
 Source logs successfully written!
-WARNING! The following target files have been modified according to git status:
-/Users/lawrencechen/Desktop/gentzkow/data/output/data_cleaned.csv
 Version logs successfully written!
 Executing command: `python  "/Users/lawrencechen/Desktop/gentzkow/analysis/code/analyze_data.py" `
 /opt/homebrew/Caskroom/miniconda/base/envs/template/lib/python3.11/site-packages/linearmodels/panel/model.py:1214: MissingValueWarning: 
@@ -15,6 +13,6 @@ Inputs contain missing values. Dropping rows with missing observations.
 
 Output logs successfully written!
 --------------------------------------------------------------------------------
-Makelog ended: 2023-10-22 16:17:53
+Makelog ended: 2023-10-23 14:05:50
 Working directory: /Users/lawrencechen/Desktop/gentzkow/analysis
 --------------------------------------------------------------------------------

--- a/analysis/log/output_stats.log
+++ b/analysis/log/output_stats.log
@@ -1,2 +1,2 @@
 file name | last modified | file size
-/Users/lawrencechen/Desktop/gentzkow/analysis/output/regression.csv | 2023-10-22 23:17:54 | 58
+/Users/lawrencechen/Desktop/gentzkow/analysis/output/regression.csv | 2023-10-23 21:05:51 | 58

--- a/analysis/log/source_stats.log
+++ b/analysis/log/source_stats.log
@@ -1,724 +1,724 @@
 file name | last modified | file size
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging.rst | 2023-10-09 08:20:29 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_r.doctree | 2023-10-11 08:11:15 | 18348
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script_error.R | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.eot | 2023-10-11 08:11:15 | 78331
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst | 2023-10-09 08:20:29 | 103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_jupyter.rst | 2023-10-09 08:20:29 | 98
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/run_program.py | 2023-10-09 08:20:29 | 42182
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data.js | 2023-10-09 08:20:29 | 4758
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad.txt | 2023-10-09 08:20:29 | 31
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst | 2023-10-09 08:20:29 | 124
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/wrong_extension.txt | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility 2.doctree | 2023-10-11 08:11:15 | 28361
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_executables.rst | 2023-10-09 08:20:29 | 120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_module.doctree | 2023-10-11 08:11:15 | 12830
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_latex.doctree | 2023-10-11 08:11:15 | 20056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst | 2023-10-09 08:20:29 | 79
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data 2.js | 2023-10-11 08:11:15 | 4758
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.eot | 2023-10-11 08:11:15 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_latex.rst | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools.js | 2023-10-09 08:20:29 | 4472
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/language_data.js | 2023-10-09 08:20:29 | 4758
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling.html | 2023-10-11 08:11:15 | 16737
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:20:38 | 1733
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory.html | 2023-10-11 08:11:15 | 12728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_perl.doctree | 2023-10-11 08:11:15 | 18527
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/program.rst | 2023-10-09 08:20:29 | 2704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold 2.ttf | 2023-10-11 08:11:15 | 109948
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_paths.rst | 2023-10-09 08:20:29 | 102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/basic.css | 2023-10-11 08:11:15 | 14621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 6626
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-311.pyc | 2023-10-11 08:12:32 | 5997
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script space.py | 2023-10-09 08:20:29 | 169
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_R.py | 2023-10-09 08:20:29 | 8001
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility 2.rst | 2023-10-11 08:11:15 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/minus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 4021
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_module_size.doctree | 2023-10-11 08:11:15 | 10689
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-311.pyc | 2023-10-11 08:12:32 | 14353
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus 2.png | 2023-10-11 08:11:15 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_empty.txt | 2023-10-09 08:20:29 | 22
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_depth.txt | 2023-10-09 08:20:29 | 65
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_externals.rst | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search 2.html | 2023-10-11 08:11:15 | 4679
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.cfg | 2023-10-09 08:20:29 | 416
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/repository.doctree | 2023-10-11 08:11:15 | 25020
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-311.pyc | 2023-10-11 08:12:35 | 15605
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex 2.html | 2023-10-11 08:11:15 | 13012
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/index.rst | 2023-10-09 08:20:29 | 1039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0 2.js | 2023-10-11 08:11:15 | 288580
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/index.html | 2023-10-11 08:11:15 | 7518
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_file.txt | 2023-10-09 08:20:29 | 64
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing.rst | 2023-10-09 08:20:29 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_missing.txt | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/latex_file.tex | 2023-10-09 08:20:29 | 276
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_matlab.doctree | 2023-10-11 08:11:15 | 18438
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/specifying_paths.doctree | 2023-10-11 08:11:15 | 17011
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/program.html | 2023-10-11 08:11:15 | 61975
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-311.pyc | 2023-10-11 08:12:32 | 45800
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
-/Users/lawrencechen/Desktop/gentzkow/data/output/data_cleaned.csv | 2023-10-22 23:17:48 | 10265592
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst | 2023-10-09 08:20:29 | 121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.doctree | 2023-10-11 08:11:15 | 9379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_empty.yaml | 2023-10-09 08:20:29 | 96
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging.doctree | 2023-10-11 08:11:15 | 20524
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy.doctree | 2023-10-11 08:11:15 | 51378
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-311.pyc | 2023-10-11 08:12:35 | 24933
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_key.txt | 2023-10-09 08:20:29 | 48
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst | 2023-10-09 08:20:29 | 118
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility.doctree | 2023-10-11 08:11:15 | 28357
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_stata.py | 2023-10-11 08:11:15 | 8010
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-311.pyc | 2023-10-11 08:12:35 | 7914
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script.py | 2023-10-09 08:20:29 | 169
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-310.pyc | 2023-10-09 08:20:38 | 13639
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-310.pyc | 2023-10-09 08:22:11 | 12235
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search.html | 2023-10-11 08:11:15 | 4762
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file.png | 2023-10-09 08:20:29 | 286
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf.py | 2023-10-09 08:20:29 | 1537
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/searchindex.js | 2023-10-11 08:11:15 | 37621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery.js | 2023-10-09 08:20:29 | 89501
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_error.lyx | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-311.pyc | 2023-10-11 08:12:32 | 22780
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling.rst | 2023-10-09 08:20:29 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 2445
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/LICENSE.txt | 2023-10-09 08:20:29 | 1083
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz 2.css | 2023-10-11 08:11:15 | 299
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_recursion.txt | 2023-10-09 08:20:29 | 34
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-310.pyc | 2023-10-09 08:22:11 | 6585
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/dependency_links.txt | 2023-10-11 08:12:24 | 1
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-311.pyc | 2023-10-11 08:12:35 | 6516
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_duplicated.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move.txt | 2023-10-09 08:20:29 | 53
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility.rst | 2023-10-09 08:20:29 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/Makefile | 2023-10-09 08:20:29 | 683
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy 2.doctree | 2023-10-11 08:11:15 | 51450
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst | 2023-10-09 08:20:29 | 116
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/index.doctree | 2023-10-11 08:11:15 | 6021
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_inputs.doctree | 2023-10-11 08:11:15 | 20928
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/SOURCES.txt | 2023-10-11 08:12:24 | 1234
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_version_logs.py | 2023-10-11 08:11:15 | 2652
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_conda_status.doctree | 2023-10-11 08:11:15 | 6185
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/make.bat | 2023-10-09 08:20:29 | 941
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_version_logs.py | 2023-10-09 08:20:29 | 2610
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file.lyx | 2023-10-09 08:20:29 | 1608
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script_error.do | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad_executables.yaml | 2023-10-09 08:20:29 | 249
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata 2.ttf | 2023-10-11 08:11:15 | 63184
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.doctree | 2023-10-11 08:11:15 | 7138
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex.html | 2023-10-11 08:11:15 | 13095
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/index.html | 2023-10-11 08:11:15 | 7518
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_executables.doctree | 2023-10-11 08:11:15 | 9857
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-310.pyc | 2023-10-09 08:22:11 | 2192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/plus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst | 2023-10-09 08:20:29 | 97
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_local/file_local.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/repository.html | 2023-10-11 08:11:15 | 11230
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy.html | 2023-10-11 08:11:15 | 18203
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/plus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir/file.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_bad.yaml | 2023-10-09 08:20:29 | 987
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery 2.js | 2023-10-11 08:11:15 | 89501
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_error.py | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling 2.doctree | 2023-10-11 08:11:15 | 28798
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic 2.css | 2023-10-11 08:11:15 | 14621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.execute_command.rst | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script space.do | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects.inv | 2023-10-11 08:11:15 | 1957
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_extra_input.lyx | 2023-10-09 08:20:29 | 1736
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_inputs.doctree | 2023-10-11 08:11:15 | 21381
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold 2.ttf | 2023-10-11 08:11:15 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.eot | 2023-10-11 08:11:15 | 79520
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging.rst | 2023-10-09 08:20:29 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_too_many_values.lyx | 2023-10-09 08:20:29 | 4701
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.doctree | 2023-10-11 08:11:15 | 19320
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-310.pyc | 2023-10-09 08:22:12 | 6488
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery.js | 2023-10-09 08:20:29 | 89501
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/environment.pickle | 2023-10-11 08:11:15 | 101644
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-310.pyc | 2023-10-09 08:22:12 | 18417
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-310.pyc | 2023-10-09 08:22:12 | 5672
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-310.pyc | 2023-10-09 08:22:11 | 17872
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst | 2023-10-09 08:20:29 | 115
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/utility.py | 2023-10-09 08:20:29 | 1404
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools 2.js | 2023-10-11 08:11:15 | 17120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_python.py | 2023-10-09 08:20:29 | 7064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling 2.rst | 2023-10-11 08:11:15 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-310.pyc | 2023-10-09 08:22:11 | 5617
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_matlab.rst | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_missing_input.lyx | 2023-10-09 08:20:29 | 4264
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.unzip.doctree | 2023-10-11 08:11:15 | 7173
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/not-zip-safe | 2023-10-09 08:21:08 | 1
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_wildcard.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config.yaml | 2023-10-09 08:20:29 | 1004
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging 2.rst | 2023-10-11 08:11:15 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/program.doctree | 2023-10-11 08:11:15 | 215270
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_move_sources.py | 2023-10-09 08:20:29 | 7262
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_arg.pl | 2023-10-09 08:20:29 | 206
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/README.md | 2023-10-11 08:11:15 | 2006
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy.rst | 2023-10-09 08:20:29 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_tablefill.py | 2023-10-09 08:20:29 | 4244
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-310.pyc | 2023-10-09 08:22:11 | 8943
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/repository.html | 2023-10-11 08:11:15 | 11230
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling.html | 2023-10-11 08:11:15 | 16737
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template space.lyx | 2023-10-09 08:20:29 | 4256
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file space.lyx | 2023-10-09 08:20:29 | 1608
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing.doctree | 2023-10-11 08:11:15 | 78994
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script_error.m | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/README.md | 2023-10-09 08:20:29 | 830
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_not_enough_values.lyx | 2023-10-09 08:20:29 | 3823
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff | 2023-10-11 08:11:15 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_dir.txt | 2023-10-09 08:20:29 | 54
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/searchindex.js | 2023-10-11 08:11:15 | 37621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script.do | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script space.pl | 2023-10-09 08:20:29 | 208
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_python.py | 2023-10-11 08:11:15 | 7056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_lyx.rst | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging 2.rst | 2023-10-11 08:11:15 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-310.pyc | 2023-10-09 08:22:12 | 5143
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments.css | 2023-10-11 08:11:15 | 4819
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout_handout.lyx.bak | 2023-10-09 08:20:29 | 2000
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/genindex.html | 2023-10-11 08:11:15 | 13095
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_r.rst | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools 2.js | 2023-10-11 08:11:15 | 8171
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.doctree | 2023-10-11 08:11:15 | 8736
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-311.pyc | 2023-10-11 08:12:32 | 20859
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script space.R | 2023-10-09 08:20:29 | 100
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.copy_output.rst | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user.yaml | 2023-10-09 08:20:29 | 236
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory.doctree | 2023-10-11 08:11:15 | 27253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/search.html | 2023-10-11 08:11:15 | 4762
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.ttf | 2023-10-11 08:11:15 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic.css | 2023-10-11 08:11:15 | 14621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments 2.css | 2023-10-11 08:11:15 | 4819
-/Users/lawrencechen/Desktop/gentzkow/lib/__init__.py | 2023-10-20 22:14:41 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/repository.rst | 2023-10-09 08:20:29 | 363
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/recursion.txt | 2023-10-09 08:20:29 | 34
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_paths.doctree | 2023-10-11 08:11:15 | 7155
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file 2.png | 2023-10-11 08:11:15 | 286
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/CODE_OF_CONDUCT.md | 2023-10-09 08:20:29 | 3353
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-311.pyc | 2023-10-11 08:12:32 | 2336
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script.m | 2023-10-09 08:20:29 | 84
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file space.txt | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore.js | 2023-10-09 08:20:29 | 19530
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_arg.py | 2023-10-09 08:20:29 | 180
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz.css | 2023-10-09 08:20:29 | 299
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_error.pl | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-311.pyc | 2023-10-11 08:12:32 | 2598
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move space.txt | 2023-10-09 08:20:29 | 76
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst | 2023-10-09 08:20:29 | 85
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.doctree | 2023-10-11 08:11:15 | 12579
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.execute_command.doctree | 2023-10-11 08:11:15 | 15448
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.start_makelog.doctree | 2023-10-11 08:11:15 | 7667
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/utility.py | 2023-10-09 08:20:29 | 1404
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script space.m | 2023-10-09 08:20:29 | 84
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_R.py | 2023-10-11 08:11:15 | 7997
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging 2.doctree | 2023-10-11 08:11:15 | 35515
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst | 2023-10-09 08:20:29 | 94
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_module.rst | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file.txt | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/specifying_paths.rst | 2023-10-09 08:20:29 | 2616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing 2.rst | 2023-10-11 08:11:15 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments.lyx | 2023-10-09 08:20:29 | 1694
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular 2.ttf | 2023-10-11 08:11:15 | 656568
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/top_level.txt | 2023-10-11 08:12:24 | 16
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst | 2023-10-09 08:20:29 | 122
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/tablefill/gslab_make.tablefill.tablefill.doctree | 2023-10-11 08:11:15 | 27880
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf 2.py | 2023-10-11 08:11:15 | 1537
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad.yaml | 2023-10-09 08:20:29 | 131
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff2 | 2023-10-11 08:11:15 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-311.pyc | 2023-10-11 08:12:32 | 19226
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir space/file space.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/run_program.py | 2023-10-11 08:11:15 | 42191
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/file.png | 2023-10-09 08:20:29 | 286
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/objects.inv | 2023-10-11 08:11:15 | 1957
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/README.md | 2023-10-09 08:20:29 | 1340
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill space.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-311.pyc | 2023-10-11 08:12:35 | 9379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular 2.ttf | 2023-10-11 08:11:15 | 96964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0 2.js | 2023-10-11 08:11:15 | 67692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1 2.js | 2023-10-11 08:11:15 | 68420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_external_paths.doctree | 2023-10-11 08:11:15 | 9851
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_move_sources.py | 2023-10-11 08:11:15 | 7274
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.doctree | 2023-10-11 08:11:15 | 8103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_externals.doctree | 2023-10-11 08:11:15 | 21024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1 2.js | 2023-10-11 08:11:15 | 35168
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.doctree | 2023-10-11 08:11:15 | 17521
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.tex | 2023-10-09 08:20:29 | 942
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/program.html | 2023-10-11 08:11:15 | 61975
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-311.pyc | 2023-10-11 08:12:32 | 10102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stata.doctree | 2023-10-11 08:11:15 | 19271
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/metadata.py | 2023-10-09 08:20:29 | 4133
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy.html | 2023-10-11 08:11:15 | 18203
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script.R | 2023-10-09 08:20:29 | 100
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/graphviz.css | 2023-10-09 08:20:29 | 299
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/doctools.js | 2023-10-09 08:20:29 | 4472
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1 2.js | 2023-10-11 08:11:15 | 287630
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst | 2023-10-09 08:20:29 | 91
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/__init__.py | 2023-10-11 08:11:15 | 2696
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.woff2 | 2023-10-11 08:11:15 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility.html | 2023-10-11 08:11:15 | 12008
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.copy_output.doctree | 2023-10-11 08:11:15 | 7228
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory 2.doctree | 2023-10-11 08:11:15 | 27257
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular 2.ttf | 2023-10-11 08:11:15 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/tablefill/gslab_make.tablefill.tablefill.rst | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stata.rst | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.doctree | 2023-10-11 08:11:15 | 10625
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/metadata.py | 2023-10-11 08:11:15 | 4133
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-310.pyc | 2023-10-09 08:22:11 | 6991
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout.lyx | 2023-10-09 08:20:29 | 2000
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy 2.rst | 2023-10-11 08:11:15 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-310.pyc | 2023-10-09 08:22:11 | 1478
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory.rst | 2023-10-09 08:20:29 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory.html | 2023-10-11 08:11:15 | 12728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging.doctree | 2023-10-11 08:11:15 | 35511
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold 2.ttf | 2023-10-11 08:11:15 | 656544
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-310.pyc | 2023-10-09 08:22:11 | 31852
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_lyx.doctree | 2023-10-11 08:11:15 | 22160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff | 2023-10-11 08:11:15 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_mathematica.doctree | 2023-10-11 08:11:15 | 18528
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-311.pyc | 2023-10-11 08:12:32 | 10420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-310.pyc | 2023-10-09 08:22:12 | 10123
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stat_transfer.doctree | 2023-10-11 08:11:15 | 18750
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script.pl | 2023-10-09 08:20:29 | 208
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 183
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_sas.rst | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_python.doctree | 2023-10-11 08:11:15 | 18563
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore.js | 2023-10-09 08:20:29 | 19530
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff2 | 2023-10-11 08:11:15 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects 2.inv | 2023-10-11 08:11:15 | 1891
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_no_tag.txt | 2023-10-09 08:20:29 | 56
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 4671
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling.doctree | 2023-10-11 08:11:15 | 28794
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_wildcard.txt | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility.html | 2023-10-11 08:11:15 | 12008
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__init__.py | 2023-10-09 08:20:29 | 2756
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.ttf | 2023-10-11 08:11:15 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.lyx | 2023-10-09 08:20:29 | 4256
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.ttf | 2023-10-11 08:11:15 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat 2.js | 2023-10-11 08:11:15 | 4418
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/PKG-INFO | 2023-10-11 08:12:24 | 2432
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir space/file space.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/requires.txt | 2023-10-11 08:12:24 | 69
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_mathematica.rst | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_externals.doctree | 2023-10-11 08:11:15 | 21477
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move space.txt | 2023-10-09 08:20:29 | 65
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-310.pyc | 2023-10-09 08:22:12 | 18417
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_recursion.txt | 2023-10-09 08:20:29 | 34
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_sas.doctree | 2023-10-11 08:11:15 | 20509
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_python.rst | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_jupyter.doctree | 2023-10-11 08:11:15 | 13990
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_stata.py | 2023-10-09 08:20:29 | 8022
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_beamer.lyx | 2023-10-09 08:20:29 | 2000
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory 2.rst | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_wildcard.txt | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-310.pyc | 2023-10-09 08:22:11 | 8943
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script space.R | 2023-10-09 08:20:29 | 100
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy 2.rst | 2023-10-11 08:11:15 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_matlab.doctree | 2023-10-11 08:11:15 | 18438
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling 2.doctree | 2023-10-11 08:11:15 | 28798
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.woff2 | 2023-10-11 08:11:15 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_executables.rst | 2023-10-09 08:20:29 | 120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.start_makelog.doctree | 2023-10-11 08:11:15 | 7667
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/genindex.html | 2023-10-11 08:11:15 | 13095
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst | 2023-10-09 08:20:29 | 124
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory 2.doctree | 2023-10-11 08:11:15 | 27257
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:22:11 | 169
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing 2.doctree | 2023-10-11 08:11:15 | 78998
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.end_makelog.doctree | 2023-10-11 08:11:15 | 7377
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 2407
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.py | 2023-10-09 08:20:29 | 738
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir/file.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 4021
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-310.pyc | 2023-10-09 08:22:11 | 2192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1 2.js | 2023-10-11 08:11:15 | 68420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.tex | 2023-10-09 08:20:29 | 942
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-311.pyc | 2023-10-11 08:12:35 | 15605
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments_comments.lyx.bak | 2023-10-09 08:20:29 | 1694
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_tablefill.py | 2023-10-11 08:11:15 | 4248
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing 2.rst | 2023-10-11 08:11:15 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script space.py | 2023-10-09 08:20:29 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic.css | 2023-10-11 08:11:15 | 14621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0 2.js | 2023-10-11 08:11:15 | 288580
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script_error.m | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex.html | 2023-10-11 08:11:15 | 13095
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/wrong_extension.txt | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments 2.css | 2023-10-11 08:11:15 | 4819
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_jupyter.rst | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.copy_output.rst | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_error.lyx | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.unzip.doctree | 2023-10-11 08:11:15 | 7173
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore.js | 2023-10-09 08:20:29 | 19530
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user.yaml | 2023-10-09 08:20:29 | 236
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/index.html | 2023-10-11 08:11:15 | 7518
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script.py | 2023-10-09 08:20:29 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1 2.js | 2023-10-11 08:11:15 | 35168
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst | 2023-10-09 08:20:29 | 122
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_lyx.doctree | 2023-10-11 08:11:15 | 22160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file.png | 2023-10-09 08:20:29 | 286
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/language_data.js | 2023-10-09 08:20:29 | 4758
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst | 2023-10-09 08:20:29 | 97
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging 2.doctree | 2023-10-11 08:11:15 | 20528
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_perl.rst | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory.doctree | 2023-10-11 08:11:15 | 27253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/top_level.txt | 2023-10-11 08:12:24 | 16
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex 2.html | 2023-10-11 08:11:15 | 13012
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/pygments.css | 2023-10-11 08:11:15 | 4819
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling 2.rst | 2023-10-11 08:11:15 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_jupyter.doctree | 2023-10-11 08:11:15 | 13990
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 4671
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools.js | 2023-10-09 08:20:29 | 4472
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_duplicated.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_too_many_values.lyx | 2023-10-09 08:20:29 | 4701
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_stata.py | 2023-10-11 08:11:15 | 8010
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir space/file space.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory.html | 2023-10-11 08:11:15 | 12728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/README.md | 2023-10-11 08:11:15 | 2006
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.lyx | 2023-10-09 08:20:29 | 4256
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_empty.txt | 2023-10-09 08:20:29 | 22
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst | 2023-10-09 08:20:29 | 85
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-311.pyc | 2023-10-11 08:12:32 | 45800
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular 2.ttf | 2023-10-11 08:11:15 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_mathematica.rst | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 2407
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging.doctree | 2023-10-11 08:11:15 | 20524
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/SOURCES.txt | 2023-10-11 08:12:24 | 1234
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools 2.js | 2023-10-11 08:11:15 | 17120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-311.pyc | 2023-10-11 08:12:32 | 10102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/plus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_no_tag.txt | 2023-10-09 08:20:29 | 56
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/metadata.py | 2023-10-11 08:11:15 | 4133
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:20:38 | 1733
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 2445
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.doctree | 2023-10-11 08:11:15 | 17521
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging.rst | 2023-10-09 08:20:29 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.execute_command.rst | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-311.pyc | 2023-10-11 08:12:32 | 22780
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_tablefill.py | 2023-10-11 08:11:15 | 4248
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory 2.rst | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_depth.txt | 2023-10-09 08:20:29 | 65
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/tablefill/gslab_make.tablefill.tablefill.rst | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery 2.js | 2023-10-11 08:11:15 | 89501
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/index.rst | 2023-10-09 08:20:29 | 1039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging.doctree | 2023-10-11 08:11:15 | 35511
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move.txt | 2023-10-09 08:20:29 | 53
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_latex.doctree | 2023-10-11 08:11:15 | 20056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_arg.pl | 2023-10-09 08:20:29 | 206
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data.js | 2023-10-09 08:20:29 | 4758
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script space.pl | 2023-10-09 08:20:29 | 208
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_version_logs.py | 2023-10-09 08:20:29 | 2610
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/objects.inv | 2023-10-11 08:11:15 | 1957
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/requires.txt | 2023-10-11 08:12:24 | 69
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_inputs.doctree | 2023-10-11 08:11:15 | 21381
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
+/Users/lawrencechen/Desktop/gentzkow/data/output/data_cleaned.csv | 2023-10-23 21:05:46 | 10265592
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/recursion.txt | 2023-10-09 08:20:29 | 34
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_extra_input.lyx | 2023-10-09 08:20:29 | 1736
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file 2.png | 2023-10-11 08:11:15 | 286
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/CODE_OF_CONDUCT.md | 2023-10-09 08:20:29 | 3353
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script.R | 2023-10-09 08:20:29 | 100
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1 2.js | 2023-10-11 08:11:15 | 287630
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/search.html | 2023-10-11 08:11:15 | 4762
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_module.doctree | 2023-10-11 08:11:15 | 12830
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-311.pyc | 2023-10-11 08:12:32 | 5997
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_python.py | 2023-10-09 08:20:29 | 7064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.eot | 2023-10-11 08:11:15 | 78331
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy.html | 2023-10-11 08:11:15 | 18203
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-310.pyc | 2023-10-09 08:22:11 | 31852
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/dependency_links.txt | 2023-10-11 08:12:24 | 1
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst | 2023-10-09 08:20:29 | 103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_python.py | 2023-10-11 08:11:15 | 7056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search 2.html | 2023-10-11 08:11:15 | 4679
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad.txt | 2023-10-09 08:20:29 | 31
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.doctree | 2023-10-11 08:11:15 | 7138
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-311.pyc | 2023-10-11 08:12:32 | 14353
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular 2.ttf | 2023-10-11 08:11:15 | 656568
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_not_enough_values.lyx | 2023-10-09 08:20:29 | 3823
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_tablefill.py | 2023-10-09 08:20:29 | 4244
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility.doctree | 2023-10-11 08:11:15 | 28357
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_missing_input.lyx | 2023-10-09 08:20:29 | 4264
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_conda_status.doctree | 2023-10-11 08:11:15 | 6185
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore.js | 2023-10-09 08:20:29 | 19530
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_error.py | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data 2.js | 2023-10-11 08:11:15 | 4758
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.doctree | 2023-10-11 08:11:15 | 8103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/run_program.py | 2023-10-09 08:20:29 | 42182
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments_comments.lyx.bak | 2023-10-09 08:20:29 | 1694
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing.doctree | 2023-10-11 08:11:15 | 78994
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility.html | 2023-10-11 08:11:15 | 12008
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_mathematica.doctree | 2023-10-11 08:11:15 | 18528
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging 2.rst | 2023-10-11 08:11:15 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-311.pyc | 2023-10-11 08:12:35 | 6516
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_move_sources.py | 2023-10-11 08:11:15 | 7274
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff2 | 2023-10-11 08:11:15 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/README.md | 2023-10-09 08:20:29 | 1340
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file.lyx | 2023-10-09 08:20:29 | 1608
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/environment.pickle | 2023-10-11 08:11:15 | 101644
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script_error.R | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stata.doctree | 2023-10-11 08:11:15 | 19271
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing.rst | 2023-10-09 08:20:29 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery.js | 2023-10-09 08:20:29 | 89501
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.py | 2023-10-09 08:20:29 | 738
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_python.doctree | 2023-10-11 08:11:15 | 18563
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_beamer.lyx | 2023-10-09 08:20:29 | 2000
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_externals.doctree | 2023-10-11 08:11:15 | 21477
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/utility.py | 2023-10-09 08:20:29 | 1404
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-310.pyc | 2023-10-09 08:22:12 | 5143
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst | 2023-10-09 08:20:29 | 79
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata 2.ttf | 2023-10-11 08:11:15 | 63184
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-311.pyc | 2023-10-11 08:12:32 | 2598
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst | 2023-10-09 08:20:29 | 118
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_inputs.doctree | 2023-10-11 08:11:15 | 20928
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stat_transfer.doctree | 2023-10-11 08:11:15 | 18750
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-310.pyc | 2023-10-09 08:22:11 | 17872
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script_error.do | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file.txt | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility 2.doctree | 2023-10-11 08:11:15 | 28361
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging 2.doctree | 2023-10-11 08:11:15 | 35515
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script space.do | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects.inv | 2023-10-11 08:11:15 | 1957
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.doctree | 2023-10-11 08:11:15 | 8736
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz 2.css | 2023-10-11 08:11:15 | 299
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/index.doctree | 2023-10-11 08:11:15 | 6021
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-311.pyc | 2023-10-11 08:12:35 | 9379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_python.rst | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst | 2023-10-09 08:20:29 | 94
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/make.bat | 2023-10-09 08:20:29 | 941
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/utility.py | 2023-10-09 08:20:29 | 1404
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_executables.doctree | 2023-10-11 08:11:15 | 9857
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move space.txt | 2023-10-09 08:20:29 | 65
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_r.rst | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular 2.ttf | 2023-10-11 08:11:15 | 96964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff | 2023-10-11 08:11:15 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_file.txt | 2023-10-09 08:20:29 | 64
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/not-zip-safe | 2023-10-09 08:21:08 | 1
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools 2.js | 2023-10-11 08:11:15 | 8171
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/file.png | 2023-10-09 08:20:29 | 286
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-310.pyc | 2023-10-09 08:22:11 | 1478
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/doctools.js | 2023-10-09 08:20:29 | 4472
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_sas.rst | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_external_paths.doctree | 2023-10-11 08:11:15 | 9851
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_paths.doctree | 2023-10-11 08:11:15 | 7155
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad_executables.yaml | 2023-10-09 08:20:29 | 249
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_perl.rst | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/LICENSE.txt | 2023-10-09 08:20:29 | 1083
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__init__.py | 2023-10-09 08:20:29 | 2756
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-311.pyc | 2023-10-11 08:12:35 | 7914
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling.html | 2023-10-11 08:11:15 | 16737
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout.lyx | 2023-10-09 08:20:29 | 2000
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_empty.yaml | 2023-10-09 08:20:29 | 96
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script space.m | 2023-10-09 08:20:29 | 84
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.doctree | 2023-10-11 08:11:15 | 19320
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/graphviz.css | 2023-10-09 08:20:29 | 299
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_externals.doctree | 2023-10-11 08:11:15 | 21024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments.lyx | 2023-10-09 08:20:29 | 1694
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_version_logs.py | 2023-10-11 08:11:15 | 2652
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/program.rst | 2023-10-09 08:20:29 | 2704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script.m | 2023-10-09 08:20:29 | 84
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_perl.doctree | 2023-10-11 08:11:15 | 18527
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_stata.py | 2023-10-09 08:20:29 | 8022
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/repository.rst | 2023-10-09 08:20:29 | 363
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.eot | 2023-10-11 08:11:15 | 79520
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script.do | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-310.pyc | 2023-10-09 08:22:11 | 6585
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold 2.ttf | 2023-10-11 08:11:15 | 109948
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.end_makelog.doctree | 2023-10-11 08:11:15 | 7377
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff | 2023-10-11 08:11:15 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-310.pyc | 2023-10-09 08:22:12 | 5672
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.doctree | 2023-10-11 08:11:15 | 9379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_wildcard.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill space.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf 2.py | 2023-10-11 08:11:15 | 1537
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic 2.css | 2023-10-11 08:11:15 | 14621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/repository.doctree | 2023-10-11 08:11:15 | 25020
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad.yaml | 2023-10-09 08:20:29 | 131
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_paths.rst | 2023-10-09 08:20:29 | 102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging.rst | 2023-10-09 08:20:29 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search.html | 2023-10-11 08:11:15 | 4762
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_matlab.rst | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_error.pl | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-311.pyc | 2023-10-11 08:12:32 | 19226
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery.js | 2023-10-09 08:20:29 | 89501
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/program.html | 2023-10-11 08:11:15 | 61975
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling.rst | 2023-10-09 08:20:29 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf.py | 2023-10-09 08:20:29 | 1537
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_move_sources.py | 2023-10-09 08:20:29 | 7262
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-311.pyc | 2023-10-11 08:12:32 | 10420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_R.py | 2023-10-11 08:11:15 | 7997
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir space/file space.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_dir.txt | 2023-10-09 08:20:29 | 54
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_externals.rst | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir/file.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.cfg | 2023-10-09 08:20:29 | 416
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout_handout.lyx.bak | 2023-10-09 08:20:29 | 2000
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging 2.rst | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file space.lyx | 2023-10-09 08:20:29 | 1608
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.ttf | 2023-10-11 08:11:15 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy.rst | 2023-10-09 08:20:29 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-310.pyc | 2023-10-09 08:22:12 | 6488
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff2 | 2023-10-11 08:11:15 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_latex.rst | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_module_size.doctree | 2023-10-11 08:11:15 | 10689
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling.doctree | 2023-10-11 08:11:15 | 28794
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file space.txt | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst | 2023-10-09 08:20:29 | 121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility 2.rst | 2023-10-11 08:11:15 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-310.pyc | 2023-10-09 08:22:11 | 12235
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir/file.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-311.pyc | 2023-10-11 08:12:32 | 20859
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling.html | 2023-10-11 08:11:15 | 16737
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst | 2023-10-09 08:20:29 | 91
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/specifying_paths.doctree | 2023-10-11 08:11:15 | 17011
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script.pl | 2023-10-09 08:20:29 | 208
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_lyx.rst | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing 2.doctree | 2023-10-11 08:11:15 | 78998
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory.rst | 2023-10-09 08:20:29 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/program.doctree | 2023-10-11 08:11:15 | 215270
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/tablefill/gslab_make.tablefill.tablefill.doctree | 2023-10-11 08:11:15 | 27880
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/latex_file.tex | 2023-10-09 08:20:29 | 276
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_bad.yaml | 2023-10-09 08:20:29 | 987
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/PKG-INFO | 2023-10-11 08:12:24 | 2432
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/README.md | 2023-10-09 08:20:29 | 830
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.ttf | 2023-10-11 08:11:15 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-310.pyc | 2023-10-09 08:22:11 | 6991
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-310.pyc | 2023-10-09 08:20:38 | 13639
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/program.html | 2023-10-11 08:11:15 | 61975
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stata.rst | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility.rst | 2023-10-09 08:20:29 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-310.pyc | 2023-10-09 08:22:12 | 10123
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-310.pyc | 2023-10-09 08:22:11 | 5617
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy 2.doctree | 2023-10-11 08:11:15 | 51450
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:22:11 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_key.txt | 2023-10-09 08:20:29 | 48
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0 2.js | 2023-10-11 08:11:15 | 67692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/repository.html | 2023-10-11 08:11:15 | 11230
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus 2.png | 2023-10-11 08:11:15 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 183
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 6626
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_local/file_local.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/repository.html | 2023-10-11 08:11:15 | 11230
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz.css | 2023-10-09 08:20:29 | 299
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/specifying_paths.rst | 2023-10-09 08:20:29 | 2616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.execute_command.doctree | 2023-10-11 08:11:15 | 15448
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.doctree | 2023-10-11 08:11:15 | 12579
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_module.rst | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template space.lyx | 2023-10-09 08:20:29 | 4256
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config.yaml | 2023-10-09 08:20:29 | 1004
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.copy_output.doctree | 2023-10-11 08:11:15 | 7228
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/index.html | 2023-10-11 08:11:15 | 7518
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move space.txt | 2023-10-09 08:20:29 | 76
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory.html | 2023-10-11 08:11:15 | 12728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.eot | 2023-10-11 08:11:15 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.ttf | 2023-10-11 08:11:15 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy.html | 2023-10-11 08:11:15 | 18203
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_R.py | 2023-10-09 08:20:29 | 8001
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility.html | 2023-10-11 08:11:15 | 12008
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
+/Users/lawrencechen/Desktop/gentzkow/lib/__init__.py | 2023-10-20 22:14:41 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/searchindex.js | 2023-10-11 08:11:15 | 37621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects 2.inv | 2023-10-11 08:11:15 | 1891
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-311.pyc | 2023-10-11 08:12:32 | 2336
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/basic.css | 2023-10-11 08:11:15 | 14621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/run_program.py | 2023-10-11 08:11:15 | 42191
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_arg.py | 2023-10-09 08:20:29 | 180
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.doctree | 2023-10-11 08:11:15 | 10625
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst | 2023-10-09 08:20:29 | 116
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/minus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/searchindex.js | 2023-10-11 08:11:15 | 37621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/metadata.py | 2023-10-09 08:20:29 | 4133
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_r.doctree | 2023-10-11 08:11:15 | 18348
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat 2.js | 2023-10-11 08:11:15 | 4418
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments.css | 2023-10-11 08:11:15 | 4819
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_missing.txt | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/__init__.py | 2023-10-11 08:11:15 | 2696
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/Makefile | 2023-10-09 08:20:29 | 683
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy.doctree | 2023-10-11 08:11:15 | 51378
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/plus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold 2.ttf | 2023-10-11 08:11:15 | 656544
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold 2.ttf | 2023-10-11 08:11:15 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741

--- a/analysis/log/versions.log
+++ b/analysis/log/versions.log
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------
-Versions log started: 2023-10-22 16:17:50
+Versions log started: 2023-10-23 14:05:48
 --------------------------------------------------------------------------------
 # packages in environment at /opt/homebrew/Caskroom/miniconda/base/envs/template:
 #

--- a/data/log/make.log
+++ b/data/log/make.log
@@ -1,13 +1,10 @@
 --------------------------------------------------------------------------------
-Makelog started: 2023-10-22 16:42:26
+Makelog started: 2023-10-23 14:05:41
 Working directory: /Users/lawrencechen/Desktop/gentzkow/data
 --------------------------------------------------------------------------------
 Input links successfully created!
 External links successfully created!
 Source logs successfully written!
-WARNING! The following target files have been modified according to git status:
-/Users/lawrencechen/Desktop/gentzkow/raw/tv.csv
-/Users/lawrencechen/Desktop/gentzkow/raw/chips.csv
 Version logs successfully written!
 Executing command: `python  "/Users/lawrencechen/Desktop/gentzkow/data/code/merge_data.py" `
 Executing command: `python  "/Users/lawrencechen/Desktop/gentzkow/data/code/clean_data.py" `
@@ -19,6 +16,6 @@ See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stab
 
 Output logs successfully written!
 --------------------------------------------------------------------------------
-Makelog ended: 2023-10-22 16:42:32
+Makelog ended: 2023-10-23 14:05:46
 Working directory: /Users/lawrencechen/Desktop/gentzkow/data
 --------------------------------------------------------------------------------

--- a/data/log/output_stats.log
+++ b/data/log/output_stats.log
@@ -1,4 +1,4 @@
 file name | last modified | file size
-/Users/lawrencechen/Desktop/gentzkow/data/output/data_merged.csv | 2023-10-22 23:42:30 | 10294275
-/Users/lawrencechen/Desktop/gentzkow/data/output/data_cleaned.csv | 2023-10-22 23:42:32 | 10265592
-/Users/lawrencechen/Desktop/gentzkow/data/output/chips_sold.pdf | 2023-10-22 23:42:31 | 9940
+/Users/lawrencechen/Desktop/gentzkow/data/output/data_merged.csv | 2023-10-23 21:05:44 | 10294275
+/Users/lawrencechen/Desktop/gentzkow/data/output/data_cleaned.csv | 2023-10-23 21:05:46 | 10265592
+/Users/lawrencechen/Desktop/gentzkow/data/output/chips_sold.pdf | 2023-10-23 21:05:45 | 9940

--- a/data/log/source_stats.log
+++ b/data/log/source_stats.log
@@ -1,725 +1,725 @@
 file name | last modified | file size
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script.py | 2023-10-09 08:20:29 | 169
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery 2.js | 2023-10-11 08:11:15 | 89501
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_missing.txt | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/requires.txt | 2023-10-11 08:12:24 | 69
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus 2.png | 2023-10-11 08:11:15 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.doctree | 2023-10-11 08:11:15 | 7138
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad_executables.yaml | 2023-10-09 08:20:29 | 249
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-310.pyc | 2023-10-09 08:20:38 | 13639
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.start_makelog.doctree | 2023-10-11 08:11:15 | 7667
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/make.bat | 2023-10-09 08:20:29 | 941
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/repository.doctree | 2023-10-11 08:11:15 | 25020
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_dir.txt | 2023-10-09 08:20:29 | 54
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy.rst | 2023-10-09 08:20:29 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging.doctree | 2023-10-11 08:11:15 | 20524
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst | 2023-10-09 08:20:29 | 116
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/specifying_paths.rst | 2023-10-09 08:20:29 | 2616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst | 2023-10-09 08:20:29 | 91
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 4021
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff2 | 2023-10-11 08:11:15 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular 2.ttf | 2023-10-11 08:11:15 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_matlab.doctree | 2023-10-11 08:11:15 | 18438
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/plus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools.js | 2023-10-09 08:20:29 | 4472
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_perl.rst | 2023-10-09 08:20:29 | 89
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst | 2023-10-09 08:20:29 | 115
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.copy_output.doctree | 2023-10-11 08:11:15 | 7228
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stata.doctree | 2023-10-11 08:11:15 | 19271
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling.html | 2023-10-11 08:11:15 | 16737
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_module_size.doctree | 2023-10-11 08:11:15 | 10689
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file space.txt | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-311.pyc | 2023-10-11 08:12:35 | 15605
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script space.m | 2023-10-09 08:20:29 | 84
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility 2.doctree | 2023-10-11 08:11:15 | 28361
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling.html | 2023-10-11 08:11:15 | 16737
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold 2.ttf | 2023-10-11 08:11:15 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility.html | 2023-10-11 08:11:15 | 12008
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_arg.pl | 2023-10-09 08:20:29 | 206
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.eot | 2023-10-11 08:11:15 | 78331
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:22:11 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_latex.doctree | 2023-10-11 08:11:15 | 20056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_r.doctree | 2023-10-11 08:11:15 | 18348
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:20:38 | 1733
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_jupyter.rst | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects 2.inv | 2023-10-11 08:11:15 | 1891
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/plus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_module.doctree | 2023-10-11 08:11:15 | 12830
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir space/file space.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1 2.js | 2023-10-11 08:11:15 | 35168
+/Users/lawrencechen/Desktop/gentzkow/raw/chips.csv | 2023-10-11 08:02:46 | 8758851
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory.doctree | 2023-10-11 08:11:15 | 27253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery.js | 2023-10-09 08:20:29 | 89501
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/program.html | 2023-10-11 08:11:15 | 61975
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 4671
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.eot | 2023-10-11 08:11:15 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/LICENSE.txt | 2023-10-09 08:20:29 | 1083
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.lyx | 2023-10-09 08:20:29 | 4256
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-311.pyc | 2023-10-11 08:12:32 | 19226
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/environment.pickle | 2023-10-11 08:11:15 | 101644
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_bad.yaml | 2023-10-09 08:20:29 | 987
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic.css | 2023-10-11 08:11:15 | 14621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script.R | 2023-10-09 08:20:29 | 100
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst | 2023-10-09 08:20:29 | 94
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools 2.js | 2023-10-11 08:11:15 | 8171
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_empty.yaml | 2023-10-09 08:20:29 | 96
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory.html | 2023-10-11 08:11:15 | 12728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_depth.txt | 2023-10-09 08:20:29 | 65
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore.js | 2023-10-09 08:20:29 | 19530
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search 2.html | 2023-10-11 08:11:15 | 4679
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst | 2023-10-09 08:20:29 | 118
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst | 2023-10-09 08:20:29 | 91
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst | 2023-10-09 08:20:29 | 79
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_wildcard.txt | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data 2.js | 2023-10-11 08:11:15 | 4758
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_module_size.doctree | 2023-10-11 08:11:15 | 10689
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.py | 2023-10-09 08:20:29 | 738
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.execute_command.doctree | 2023-10-11 08:11:15 | 15448
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_externals.doctree | 2023-10-11 08:11:15 | 21477
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-311.pyc | 2023-10-11 08:12:35 | 7914
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.eot | 2023-10-11 08:11:15 | 79520
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-311.pyc | 2023-10-11 08:12:32 | 5997
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1 2.js | 2023-10-11 08:11:15 | 287630
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/repository.doctree | 2023-10-11 08:11:15 | 25020
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-310.pyc | 2023-10-09 08:22:11 | 17872
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling.html | 2023-10-11 08:11:15 | 16737
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move space.txt | 2023-10-09 08:20:29 | 65
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/README.md | 2023-10-09 08:20:29 | 830
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing.doctree | 2023-10-11 08:11:15 | 78994
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular 2.ttf | 2023-10-11 08:11:15 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 2407
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_move_sources.py | 2023-10-09 08:20:29 | 7262
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst | 2023-10-09 08:20:29 | 121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-310.pyc | 2023-10-09 08:22:11 | 31852
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-311.pyc | 2023-10-11 08:12:32 | 20859
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/graphviz.css | 2023-10-09 08:20:29 | 299
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout.lyx | 2023-10-09 08:20:29 | 2000
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/repository.html | 2023-10-11 08:11:15 | 11230
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_lyx.rst | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir space/file space.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0 2.js | 2023-10-11 08:11:15 | 288580
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.doctree | 2023-10-11 08:11:15 | 19320
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_executables.rst | 2023-10-09 08:20:29 | 120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.copy_output.rst | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/top_level.txt | 2023-10-11 08:12:24 | 16
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-310.pyc | 2023-10-09 08:22:11 | 6991
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing.rst | 2023-10-09 08:20:29 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/run_program.py | 2023-10-09 08:20:29 | 42182
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file.png | 2023-10-09 08:20:29 | 286
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/wrong_extension.txt | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_perl.rst | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/utility.py | 2023-10-09 08:20:29 | 1404
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.start_makelog.doctree | 2023-10-11 08:11:15 | 7667
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-311.pyc | 2023-10-11 08:12:35 | 9379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:22:11 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_sas.rst | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold 2.ttf | 2023-10-11 08:11:15 | 109948
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_executables.doctree | 2023-10-11 08:11:15 | 9857
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy.html | 2023-10-11 08:11:15 | 18203
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/metadata.py | 2023-10-11 08:11:15 | 4133
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/genindex.html | 2023-10-11 08:11:15 | 13095
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff2 | 2023-10-11 08:11:15 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory 2.doctree | 2023-10-11 08:11:15 | 27257
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.copy_output.doctree | 2023-10-11 08:11:15 | 7228
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stata.doctree | 2023-10-11 08:11:15 | 19271
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff | 2023-10-11 08:11:15 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move.txt | 2023-10-09 08:20:29 | 53
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/searchindex.js | 2023-10-11 08:11:15 | 37621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery.js | 2023-10-09 08:20:29 | 89501
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/SOURCES.txt | 2023-10-11 08:12:24 | 1234
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory.html | 2023-10-11 08:11:15 | 12728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.execute_command.rst | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-310.pyc | 2023-10-09 08:22:12 | 5672
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/file.png | 2023-10-09 08:20:29 | 286
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout_handout.lyx.bak | 2023-10-09 08:20:29 | 2000
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy.rst | 2023-10-09 08:20:29 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-311.pyc | 2023-10-11 08:12:32 | 2336
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file.txt | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_arg.py | 2023-10-09 08:20:29 | 180
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/run_program.py | 2023-10-11 08:11:15 | 42191
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging.rst | 2023-10-09 08:20:29 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__init__.py | 2023-10-09 08:20:29 | 2756
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_R.py | 2023-10-09 08:20:29 | 8001
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad_executables.yaml | 2023-10-09 08:20:29 | 249
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf 2.py | 2023-10-11 08:11:15 | 1537
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular 2.ttf | 2023-10-11 08:11:15 | 96964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/CODE_OF_CONDUCT.md | 2023-10-09 08:20:29 | 3353
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/README.md | 2023-10-11 08:11:15 | 2006
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-311.pyc | 2023-10-11 08:12:32 | 45800
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_python.py | 2023-10-09 08:20:29 | 7064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/index.html | 2023-10-11 08:11:15 | 7518
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_key.txt | 2023-10-09 08:20:29 | 48
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stata.rst | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst | 2023-10-09 08:20:29 | 97
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.end_makelog.doctree | 2023-10-11 08:11:15 | 7377
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_python.rst | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_paths.doctree | 2023-10-11 08:11:15 | 7155
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_lyx.html | 2023-10-11 08:11:15 | 12309
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst | 2023-10-09 08:20:29 | 85
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-310.pyc | 2023-10-09 08:22:12 | 5143
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_wildcard.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_latex.rst | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_inputs.doctree | 2023-10-11 08:11:15 | 21381
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/program.rst | 2023-10-09 08:20:29 | 2704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst | 2023-10-09 08:20:29 | 103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/search.html | 2023-10-11 08:11:15 | 4762
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.ttf | 2023-10-11 08:11:15 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.tex | 2023-10-09 08:20:29 | 942
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/not-zip-safe | 2023-10-09 08:21:08 | 1
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular 2.ttf | 2023-10-11 08:11:15 | 656568
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility 2.rst | 2023-10-11 08:11:15 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_missing_input.lyx | 2023-10-09 08:20:29 | 4264
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search.html | 2023-10-11 08:11:15 | 4762
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory 2.rst | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/requires.txt | 2023-10-11 08:12:24 | 69
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_not_enough_values.lyx | 2023-10-09 08:20:29 | 3823
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz.css | 2023-10-09 08:20:29 | 299
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-310.pyc | 2023-10-09 08:22:12 | 10123
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_version_logs.py | 2023-10-09 08:20:29 | 2610
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_duplicated.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.doctree | 2023-10-11 08:11:15 | 12579
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory.html | 2023-10-11 08:11:15 | 12728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy 2.rst | 2023-10-11 08:11:15 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic 2.css | 2023-10-11 08:11:15 | 14621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/tablefill/gslab_make.tablefill.tablefill.doctree | 2023-10-11 08:11:15 | 27880
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools 2.js | 2023-10-11 08:11:15 | 17120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-311.pyc | 2023-10-11 08:12:35 | 24933
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_error.lyx | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-310.pyc | 2023-10-09 08:22:12 | 18417
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_externals.doctree | 2023-10-11 08:11:15 | 21024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst | 2023-10-09 08:20:29 | 124
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/__init__.py | 2023-10-11 08:11:15 | 2696
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/minus 2.png | 2023-10-11 08:11:15 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill space.txt | 2023-10-09 08:20:29 | 66
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_file.txt | 2023-10-09 08:20:29 | 64
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/make.bat | 2023-10-09 08:20:29 | 941
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat 2.js | 2023-10-11 08:11:15 | 4418
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff2 | 2023-10-11 08:11:15 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.unzip.doctree | 2023-10-11 08:11:15 | 7173
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/index.rst | 2023-10-09 08:20:29 | 1039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_dir.txt | 2023-10-09 08:20:29 | 54
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory.rst | 2023-10-09 08:20:29 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility.html | 2023-10-11 08:11:15 | 12008
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/metadata.py | 2023-10-09 08:20:29 | 4133
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.woff2 | 2023-10-11 08:11:15 | 66444
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_perl.doctree | 2023-10-11 08:11:15 | 18527
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 4021
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_error.py | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility.rst | 2023-10-09 08:20:29 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging 2.rst | 2023-10-11 08:11:15 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-311.pyc | 2023-10-11 08:12:32 | 22780
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.ttf | 2023-10-11 08:11:15 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/repository.rst | 2023-10-09 08:20:29 | 363
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 6626
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.ttf | 2023-10-11 08:11:15 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_module.doctree | 2023-10-11 08:11:15 | 12830
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 2445
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex 2.html | 2023-10-11 08:11:15 | 13012
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file space.txt | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_python.doctree | 2023-10-11 08:11:15 | 18563
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-310.pyc | 2023-10-09 08:22:11 | 1478
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/objects.inv | 2023-10-11 08:11:15 | 1957
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move space.txt | 2023-10-09 08:20:29 | 76
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script space.m | 2023-10-09 08:20:29 | 84
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy 2.doctree | 2023-10-11 08:11:15 | 51450
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad.txt | 2023-10-09 08:20:29 | 31
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script space.pl | 2023-10-09 08:20:29 | 208
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0 2.js | 2023-10-11 08:11:15 | 67692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_local/file_local.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-311.pyc | 2023-10-11 08:12:32 | 10102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments 2.css | 2023-10-11 08:11:15 | 4819
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_empty.txt | 2023-10-09 08:20:29 | 22
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script space.do | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_mathematica.rst | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging 2.doctree | 2023-10-11 08:11:15 | 20528
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/index.html | 2023-10-11 08:11:15 | 7518
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/program.html | 2023-10-11 08:11:15 | 61975
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_empty.yaml | 2023-10-09 08:20:29 | 96
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging 2.doctree | 2023-10-11 08:11:15 | 35515
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.doctree | 2023-10-11 08:11:15 | 7138
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-310.pyc | 2023-10-09 08:22:11 | 8943
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config.yaml | 2023-10-09 08:20:29 | 1004
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/latex_file.tex | 2023-10-09 08:20:29 | 276
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst.txt | 2023-10-09 08:20:29 | 122
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_jupyter.doctree | 2023-10-11 08:11:15 | 13990
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stat_transfer.doctree | 2023-10-11 08:11:15 | 18750
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/language_data.js | 2023-10-09 08:20:29 | 4758
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-310.pyc | 2023-10-09 08:22:11 | 2192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script space.py | 2023-10-09 08:20:29 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/PKG-INFO | 2023-10-11 08:12:24 | 2432
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging.rst | 2023-10-09 08:20:29 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/minus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/specifying_paths.doctree | 2023-10-11 08:11:15 | 17011
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling.html | 2023-10-11 08:11:15 | 16737
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff | 2023-10-11 08:11:15 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst | 2023-10-09 08:20:29 | 115
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_missing.txt | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.doctree | 2023-10-11 08:11:15 | 9379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools.js | 2023-10-09 08:20:29 | 4472
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore.js | 2023-10-09 08:20:29 | 19530
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/dependency_links.txt | 2023-10-11 08:12:24 | 1
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold 2.ttf | 2023-10-11 08:11:15 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_tablefill.py | 2023-10-09 08:20:29 | 4244
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging.doctree | 2023-10-11 08:11:15 | 35511
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_stata.py | 2023-10-11 08:11:15 | 8010
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data.js | 2023-10-09 08:20:29 | 4758
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/basic.css | 2023-10-11 08:11:15 | 14621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file space.lyx | 2023-10-09 08:20:29 | 1608
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/plus.png | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_recursion.txt | 2023-10-09 08:20:29 | 34
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-311.pyc | 2023-10-11 08:12:32 | 14353
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/documentation_options.js | 2023-10-09 08:20:29 | 420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file 2.png | 2023-10-11 08:11:15 | 286
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold 2.ttf | 2023-10-11 08:11:15 | 656544
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst | 2023-10-09 08:20:29 | 116
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst | 2023-10-09 08:20:29 | 94
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_conda_status.doctree | 2023-10-11 08:11:15 | 6185
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/doctools 2.js | 2023-10-11 08:11:15 | 8171
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-310.pyc | 2023-10-09 08:22:11 | 5617
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/repository.html | 2023-10-11 08:11:15 | 11230
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing 2.doctree | 2023-10-11 08:11:15 | 78998
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing 2.rst | 2023-10-11 08:11:15 | 548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script.do | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling 2.rst | 2023-10-11 08:11:15 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery 2.js | 2023-10-11 08:11:15 | 89501
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_error.pl | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata 2.ttf | 2023-10-11 08:11:15 | 63184
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility.html | 2023-10-11 08:11:15 | 12008
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects.inv | 2023-10-11 08:11:15 | 1957
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_make_utility.py | 2023-10-09 08:20:29 | 4552
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging 2.rst | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir/file.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_version_logs.py | 2023-10-11 08:11:15 | 2652
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-310.pyc | 2023-10-09 08:22:11 | 6585
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_arg.pl | 2023-10-09 08:20:29 | 206
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script_error.do | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_lyx.doctree | 2023-10-11 08:11:15 | 22160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/program.doctree | 2023-10-11 08:11:15 | 215270
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_module.rst | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/doctools.js | 2023-10-09 08:20:29 | 4472
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_matlab.doctree | 2023-10-11 08:11:15 | 18438
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
+/Users/lawrencechen/Desktop/gentzkow/raw/tv.csv | 2023-10-11 08:02:46 | 98923
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script_error.R | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy.doctree | 2023-10-11 08:11:15 | 51378
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.doctree | 2023-10-11 08:11:15 | 8736
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script.pl | 2023-10-09 08:20:29 | 208
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/recursion.txt | 2023-10-09 08:20:29 | 34
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script_error.m | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/pygments.css | 2023-10-11 08:11:15 | 4819
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_stata.py | 2023-10-09 08:20:29 | 8022
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script space.R | 2023-10-09 08:20:29 | 100
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-311.pyc | 2023-10-11 08:12:32 | 10420
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-311.pyc | 2023-10-11 08:12:35 | 6516
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular 2.ttf | 2023-10-11 08:11:15 | 96964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill_info.py | 2023-10-09 08:20:29 | 6314
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory.html | 2023-10-11 08:11:15 | 12728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_r.rst | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.copy_output.rst | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.check_conda_status.html | 2023-10-11 08:11:15 | 7229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.html | 2023-10-11 08:11:15 | 10098
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility.rst | 2023-10-09 08:20:29 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst | 2023-10-09 08:20:29 | 103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_tablefill.py | 2023-10-11 08:11:15 | 4248
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1 2.js | 2023-10-11 08:11:15 | 68420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging 2.rst | 2023-10-11 08:11:15 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic 2.css | 2023-10-11 08:11:15 | 14621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user.yaml | 2023-10-09 08:20:29 | 236
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_mathematica.doctree | 2023-10-11 08:11:15 | 18528
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.doctree | 2023-10-11 08:11:15 | 17521
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script space.pl | 2023-10-09 08:20:29 | 208
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_wildcard.txt | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal.woff | 2023-10-09 08:20:29 | 309192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_externals.doctree | 2023-10-11 08:11:15 | 21477
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-310.pyc | 2023-10-09 08:22:11 | 8943
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_sas.rst | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/raw/tv.csv | 2023-10-11 08:02:46 | 98923
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_stata.py | 2023-10-11 08:11:15 | 8010
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search.html | 2023-10-11 08:11:15 | 4762
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging.rst | 2023-10-09 08:20:29 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.link_inputs.doctree | 2023-10-11 08:11:15 | 21381
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/CODE_OF_CONDUCT.md | 2023-10-09 08:20:29 | 3353
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing 2.rst | 2023-10-11 08:11:15 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 183
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_python.doctree | 2023-10-11 08:11:15 | 18563
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_R.py | 2023-10-09 08:20:29 | 8001
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir/file.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy.html | 2023-10-11 08:11:15 | 18203
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/README.md | 2023-10-11 08:11:15 | 2006
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/searchindex.js | 2023-10-11 08:11:15 | 37621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat.js | 2023-10-09 08:20:29 | 4418
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/__init__.py | 2023-10-11 08:11:15 | 2696
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.doctree | 2023-10-11 08:11:15 | 9379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-311.pyc | 2023-10-11 08:12:32 | 20859
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_inputs.doctree | 2023-10-11 08:11:15 | 20928
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects 2.inv | 2023-10-11 08:11:15 | 1891
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging.doctree | 2023-10-11 08:11:15 | 35511
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_error.lyx | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-310.pyc | 2023-10-09 08:22:12 | 6488
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff2 | 2023-10-11 08:11:15 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/check_repo.py | 2023-10-09 08:20:29 | 14471
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments.css | 2023-10-11 08:11:15 | 4819
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-311.pyc | 2023-10-11 08:12:35 | 9379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/program.rst | 2023-10-09 08:20:29 | 2704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.execute_command.doctree | 2023-10-11 08:11:15 | 15448
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/basic.css | 2023-10-11 08:11:15 | 14621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.ttf | 2023-10-11 08:11:15 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file.png | 2023-10-09 08:20:29 | 286
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.lyx | 2023-10-09 08:20:29 | 4256
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_error.py | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-310.pyc | 2023-10-09 08:22:11 | 31852
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_r.doctree | 2023-10-11 08:11:15 | 18348
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging 2.rst.txt | 2023-10-11 08:11:15 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-310.pyc | 2023-10-09 08:22:11 | 6991
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/sourcing 2.rst.txt | 2023-10-11 08:11:15 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/environment.pickle | 2023-10-11 08:11:15 | 101644
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_version_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 2407
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments_comments.lyx.bak | 2023-10-09 08:20:29 | 1694
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz 2.css | 2023-10-11 08:11:15 | 299
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_perl.doctree | 2023-10-11 08:11:15 | 18527
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/dummy.html | 2023-10-11 08:11:15 | 18203
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold 2.ttf | 2023-10-11 08:11:15 | 109948
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/general_logging 2.doctree | 2023-10-11 08:11:15 | 35515
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/general_logging.rst | 2023-10-09 08:20:29 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory 2.rst | 2023-10-11 08:11:15 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery.js | 2023-10-09 08:20:29 | 89501
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.ttf | 2023-10-11 08:11:15 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_version_logs.py | 2023-10-09 08:20:29 | 2610
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.py | 2023-10-09 08:20:29 | 738
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script.pl | 2023-10-09 08:20:29 | 208
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/general_logging 2.html | 2023-10-11 08:11:15 | 13422
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst | 2023-10-09 08:20:29 | 122
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments 2.css | 2023-10-11 08:11:15 | 4819
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_matlab.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-311.pyc | 2023-10-11 08:12:32 | 5997
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/doctools.js | 2023-10-09 08:20:29 | 4472
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file space.lyx | 2023-10-09 08:20:29 | 1608
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.check_module_size.html | 2023-10-11 08:11:15 | 8460
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move space.txt | 2023-10-09 08:20:29 | 65
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_python.rst | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz.css | 2023-10-09 08:20:29 | 299
-/Users/lawrencechen/Desktop/gentzkow/raw/chips.csv | 2023-10-11 08:02:46 | 8758851
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing.doctree | 2023-10-11 08:11:15 | 78994
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.html | 2023-10-11 08:11:15 | 6668
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/utility.py | 2023-10-09 08:20:29 | 1404
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst | 2023-10-09 08:20:29 | 124
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/textfill.py | 2023-10-09 08:20:29 | 5952
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.execute_command.rst | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/specifying_paths.html | 2023-10-11 08:11:15 | 11828
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility.html | 2023-10-11 08:11:15 | 12008
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.start_makelog.rst.txt | 2023-10-09 08:20:29 | 103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.6.0 2.js | 2023-10-11 08:11:15 | 288580
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script.do | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_no_tag.txt | 2023-10-09 08:20:29 | 56
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/minus.png | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/modify_dir.py | 2023-10-09 08:20:29 | 7384
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory 2.doctree | 2023-10-11 08:11:15 | 27257
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.ttf | 2023-10-09 08:20:29 | 622572
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.doctree | 2023-10-11 08:11:15 | 10625
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy 2.doctree | 2023-10-11 08:11:15 | 51450
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-310.pyc | 2023-10-09 08:22:12 | 10123
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst | 2023-10-09 08:20:29 | 121
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/setup.cfg | 2023-10-09 08:20:29 | 416
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_latex.doctree | 2023-10-11 08:11:15 | 20056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_depth/depth_1.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore.js | 2023-10-09 08:20:29 | 19530
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config.yaml | 2023-10-09 08:20:29 | 1004
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/not-zip-safe | 2023-10-09 08:21:08 | 1
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file.lyx | 2023-10-09 08:20:29 | 1608
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility.doctree | 2023-10-11 08:11:15 | 28357
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/index.html | 2023-10-11 08:11:15 | 7518
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-311.pyc | 2023-10-11 08:12:35 | 6626
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf.py | 2023-10-09 08:20:29 | 1537
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_mathematica.rst | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-311.pyc | 2023-10-11 08:12:35 | 7914
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv-printshiv.min.js | 2023-10-09 08:20:29 | 4370
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/program.rst.txt | 2023-10-09 08:20:29 | 2704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/utility.py | 2023-10-09 08:20:29 | 8202
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/README.md | 2023-10-09 08:20:29 | 1340
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad.txt | 2023-10-09 08:20:29 | 31
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_external_paths.doctree | 2023-10-11 08:11:15 | 9851
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_stat_transfer.html | 2023-10-11 08:11:15 | 11549
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/repository.rst | 2023-10-09 08:20:29 | 363
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_lyx.rst | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_r.rst.txt | 2023-10-09 08:20:29 | 80
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.doctree | 2023-10-11 08:11:15 | 8103
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.copy_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move space.txt | 2023-10-09 08:20:29 | 76
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move.txt | 2023-10-09 08:20:29 | 53
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/objects.inv | 2023-10-11 08:11:15 | 1957
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility.rst.txt | 2023-10-09 08:20:29 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/programdirective.py | 2023-10-09 08:20:29 | 10360
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling 2.doctree | 2023-10-11 08:11:15 | 28798
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_matlab.rst | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst | 2023-10-09 08:20:29 | 97
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_python.py | 2023-10-11 08:11:15 | 7056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.3.1 2.js | 2023-10-11 08:11:15 | 35168
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_beamer.lyx | 2023-10-09 08:20:29 | 2000
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/utility 2.rst | 2023-10-11 08:11:15 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/search 2.html | 2023-10-11 08:11:15 | 4679
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.start_makelog.html | 2023-10-11 08:11:15 | 7076
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst.txt | 2023-10-09 08:20:29 | 79
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/move_sources.cpython-310.pyc | 2023-10-09 08:22:11 | 17872
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-311.pyc | 2023-10-11 08:12:35 | 24933
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template space.lyx | 2023-10-09 08:20:29 | 4256
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/language_data.js | 2023-10-09 08:20:29 | 4758
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata.ttf | 2023-10-09 08:20:29 | 63184
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.unzip.doctree | 2023-10-11 08:11:15 | 7173
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.ttf | 2023-10-09 08:20:29 | 639388
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-311.pyc | 2023-10-11 08:12:32 | 2336
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.eot | 2023-10-11 08:11:15 | 79520
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/index.doctree | 2023-10-11 08:11:15 | 6021
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/file 2.png | 2023-10-11 08:11:15 | 286
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.execute_command.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/specifying_paths.rst.txt | 2023-10-09 08:20:29 | 2616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/WIP_test_latex.py | 2023-10-09 08:20:29 | 2298
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_source_logs.py | 2023-10-09 08:20:29 | 4866
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_latex.rst | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data.js | 2023-10-09 08:20:29 | 4758
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_jupyter.rst | 2023-10-09 08:20:29 | 98
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/PKG-INFO | 2023-10-11 08:12:24 | 2432
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_perl.rst.txt | 2023-10-09 08:20:29 | 89
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_tablefill.py | 2023-10-09 08:20:29 | 4244
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/_sphinx_javascript_frameworks_compat 2.js | 2023-10-11 08:11:15 | 4418
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_depth.txt | 2023-10-09 08:20:29 | 65
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_sas.doctree | 2023-10-11 08:11:15 | 20509
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_bad.yaml | 2023-10-09 08:20:29 | 987
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex 2.html | 2023-10-11 08:11:15 | 13012
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Bold 2.ttf | 2023-10-11 08:11:15 | 656544
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/index.rst | 2023-10-09 08:20:29 | 1039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_stata.html | 2023-10-11 08:11:15 | 11692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_too_many_values.lyx | 2023-10-09 08:20:29 | 4701
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/tablefill_info.py | 2023-10-09 08:20:29 | 8432
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/theme.css | 2023-10-11 08:11:15 | 131657
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/messages.py | 2023-10-09 08:20:29 | 5991
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf 2.py | 2023-10-11 08:11:15 | 1537
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/perl_script_error.pl | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_python.rst.txt | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/program.html | 2023-10-11 08:11:15 | 61975
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/program.doctree | 2023-10-11 08:11:15 | 215270
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script space.R | 2023-10-09 08:20:29 | 100
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_matlab.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_external_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_stat_transfer.doctree | 2023-10-11 08:11:15 | 18750
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_stata.py | 2023-10-09 08:20:29 | 8022
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-310.pyc | 2023-10-09 08:22:11 | 12235
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.ttf | 2023-10-11 08:11:15 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.6.0.js | 2023-10-09 08:20:29 | 288580
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold 2.woff | 2023-10-11 08:11:15 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_duplicated.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/directory 2.html | 2023-10-11 08:11:15 | 11409
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_lyx.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular 2.ttf | 2023-10-11 08:11:15 | 656568
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/wrong_extension.txt | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill space.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_latex.html | 2023-10-11 08:11:15 | 11862
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_r.html | 2023-10-11 08:11:15 | 11326
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/tablefill/gslab_make.tablefill.tablefill.doctree | 2023-10-11 08:11:15 | 27880
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling 2.rst | 2023-10-11 08:11:15 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools 2.js | 2023-10-11 08:11:15 | 17120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst.txt | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling.rst | 2023-10-09 08:20:29 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_module_size.rst.txt | 2023-10-09 08:20:29 | 115
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/sourcing 2.doctree | 2023-10-11 08:11:15 | 78998
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/index.rst.txt | 2023-10-09 08:20:29 | 1039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/tablefill.cpython-310.pyc | 2023-10-09 08:22:12 | 18417
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging 2.html | 2023-10-11 08:11:15 | 9651
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/pygments.css | 2023-10-11 08:11:15 | 4819
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.html | 2023-10-11 08:11:15 | 6964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/modify_dir.cpython-311.pyc | 2023-10-11 08:12:32 | 10420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/utility.py | 2023-10-09 08:20:29 | 1404
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/write_version_logs.py | 2023-10-11 08:11:15 | 2652
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/utility 2.html | 2023-10-11 08:11:15 | 10474
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-311.pyc | 2023-10-11 08:12:32 | 19226
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout.lyx | 2023-10-09 08:20:29 | 2000
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff | 2023-10-09 08:20:29 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.eot | 2023-10-11 08:11:15 | 78331
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/file.png | 2023-10-09 08:20:29 | 286
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_stata.rst | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/searchindex.js | 2023-10-11 08:11:15 | 37621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_empty.txt | 2023-10-09 08:20:29 | 22
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_R.py | 2023-10-11 08:11:15 | 7997
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir/file.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.html | 2023-10-11 08:11:15 | 10459
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.rst.txt | 2023-10-09 08:20:29 | 112
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/messages.cpython-310.pyc | 2023-10-09 08:22:11 | 5617
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.ttf | 2023-10-09 08:20:29 | 600856
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/latex_file.tex | 2023-10-09 08:20:29 | 276
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/tablefill/gslab_make.tablefill.tablefill.html | 2023-10-11 08:11:15 | 16380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir_local/file_local.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/index.html | 2023-10-11 08:11:15 | 7518
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/file.txt | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/language_data 2.js | 2023-10-11 08:11:15 | 4758
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-310.pyc | 2023-10-09 08:20:38 | 1733
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/graphviz.css | 2023-10-09 08:20:29 | 299
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_paths.rst | 2023-10-09 08:20:29 | 102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.woff2 | 2023-10-09 08:20:29 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/objects.inv | 2023-10-11 08:11:15 | 1957
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_makelog.py | 2023-10-09 08:20:29 | 2308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_executables.doctree | 2023-10-11 08:11:15 | 9857
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.eot | 2023-10-09 08:20:29 | 266158
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/lato-normal-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script_error.R | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.unzip.rst | 2023-10-09 08:20:29 | 79
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/write_logs/gslab_make.write_logs.end_makelog.html | 2023-10-11 08:11:15 | 6910
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/dummy 2.rst | 2023-10-11 08:11:15 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery.js | 2023-10-09 08:20:29 | 89501
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script.m | 2023-10-09 08:20:29 | 84
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-311.pyc | 2023-10-11 08:12:32 | 22780
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/source_logging 2.rst | 2023-10-11 08:11:15 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/exceptionclasses.py | 2023-10-09 08:20:29 | 943
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal.woff2 | 2023-10-09 08:20:29 | 182708
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_latex.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_move_sources.py | 2023-10-09 08:20:29 | 7262
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_not_enough_values.lyx | 2023-10-09 08:20:29 | 3823
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/dependency_links.txt | 2023-10-11 08:12:24 | 1
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0.js | 2023-10-09 08:20:29 | 67692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/sourcing.rst | 2023-10-09 08:20:29 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_module.rst | 2023-10-09 08:20:29 | 95
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_lyx.doctree | 2023-10-11 08:11:15 | 22160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_paths.doctree | 2023-10-11 08:11:15 | 7155
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/metadata.py | 2023-10-09 08:20:29 | 4133
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_executables.rst | 2023-10-09 08:20:29 | 120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill.cpython-310.pyc | 2023-10-09 08:22:12 | 5143
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.html | 2023-10-11 08:11:15 | 7175
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script_arg.py | 2023-10-09 08:20:29 | 180
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_bad_key.txt | 2023-10-09 08:20:29 | 48
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.copy_inputs.html | 2023-10-11 08:11:15 | 12310
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_handout_handout.lyx.bak | 2023-10-09 08:20:29 | 2000
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/README.md | 2023-10-09 08:20:29 | 830
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/run_program.py | 2023-10-09 08:20:29 | 42182
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/program.html | 2023-10-11 08:11:15 | 61975
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.woff2 | 2023-10-09 08:20:29 | 77160
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.woff | 2023-10-11 08:11:15 | 98024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stata.rst.txt | 2023-10-09 08:20:29 | 92
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments.lyx | 2023-10-09 08:20:29 | 1694
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_mathematica.rst.txt | 2023-10-09 08:20:29 | 110
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_externals.doctree | 2023-10-11 08:11:15 | 21024
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.copy_output.rst.txt | 2023-10-09 08:20:29 | 99
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/__init__.py | 2023-10-09 08:20:29 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst.txt | 2023-10-09 08:20:29 | 85
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script space.do | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata 2.ttf | 2023-10-11 08:11:15 | 63184
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__init__.py | 2023-10-09 08:20:29 | 2756
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/make_utility/gslab_make.make_utility.update_executables.rst.txt | 2023-10-09 08:20:29 | 120
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/stata_script_error.do | 2023-10-09 08:20:29 | 5
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script space.py | 2023-10-09 08:20:29 | 169
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_missing_input.lyx | 2023-10-09 08:20:29 | 4264
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling 2.rst.txt | 2023-10-11 08:11:15 | 253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_log_outputs.py | 2023-10-09 08:20:29 | 5111
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_log_sources.py | 2023-10-09 08:20:29 | 4585
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_inputs.html | 2023-10-11 08:11:15 | 12489
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_move_sources.py | 2023-10-11 08:11:15 | 7274
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/make_utility/gslab_make.make_utility.update_paths.rst.txt | 2023-10-09 08:20:29 | 102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/LICENSE.txt | 2023-10-09 08:20:29 | 1083
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/basic.css | 2023-10-11 08:11:15 | 14621
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad.yaml | 2023-10-09 08:20:29 | 131
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_wildcard.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-311.pyc | 2023-10-11 08:12:32 | 10102
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Inconsolata-Regular.ttf | 2023-10-09 08:20:29 | 96964
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir space/file space.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_module.html | 2023-10-11 08:11:15 | 10437
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging 2.doctree | 2023-10-11 08:11:15 | 20528
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/searchtools.js | 2023-10-09 08:20:29 | 18215
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-italic.woff | 2023-10-09 08:20:29 | 328412
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.copy_output.html | 2023-10-11 08:11:15 | 6778
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_modify_dir.py | 2023-10-09 08:20:29 | 7852
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_source_logs.cpython-310.pyc | 2023-10-09 08:22:12 | 4671
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/tablefill/gslab_make.tablefill.tablefill.rst | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/repository.html | 2023-10-11 08:11:15 | 11230
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.woff2 | 2023-10-09 08:20:29 | 67312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.doctree | 2023-10-11 08:11:15 | 19320
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/sourcing.rst.txt | 2023-10-09 08:20:29 | 548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/run_program.py | 2023-10-11 08:11:15 | 42191
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex.html | 2023-10-11 08:11:15 | 13095
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/run_program.cpython-311.pyc | 2023-10-11 08:12:32 | 45800
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/repository.html | 2023-10-11 08:11:15 | 11230
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/specifying_paths.doctree | 2023-10-11 08:11:15 | 17011
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/make_utility.cpython-310.pyc | 2023-10-09 08:22:12 | 5672
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/genindex.html | 2023-10-11 08:11:15 | 13095
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-311.pyc | 2023-10-11 08:12:32 | 2598
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.rst.txt | 2023-10-09 08:20:29 | 121
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/test_python.py | 2023-10-09 08:20:29 | 7064
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/utility.cpython-310.pyc | 2023-10-09 08:22:11 | 6585
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/directory.rst | 2023-10-09 08:20:29 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/private/metadata.py | 2023-10-11 08:11:15 | 4133
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/move_recursion.txt | 2023-10-09 08:20:29 | 34
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/move_sources/move_file.txt | 2023-10-09 08:20:29 | 64
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/exceptionclasses.cpython-310.pyc | 2023-10-09 08:22:11 | 1478
-/Users/lawrencechen/Desktop/gentzkow/lib/__init__.py | 2023-10-20 22:14:41 | 0
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.end_makelog.doctree | 2023-10-11 08:11:15 | 7377
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Inconsolata-Bold.ttf | 2023-10-09 08:20:29 | 109948
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.check_conda_status.doctree | 2023-10-11 08:11:15 | 6185
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.rst.txt | 2023-10-09 08:20:29 | 91
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.rst | 2023-10-09 08:20:29 | 129
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script_error.m | 2023-10-09 08:20:29 | 5
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility 2.doctree | 2023-10-11 08:11:15 | 28361
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/badge_only.css | 2023-10-09 08:20:29 | 3229
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 2445
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling.doctree | 2023-10-11 08:11:15 | 28794
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst | 2023-10-09 08:20:29 | 118
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-normal-italic.woff2 | 2023-10-09 08:20:29 | 195704
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template.tex | 2023-10-09 08:20:29 | 942
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_paths.html | 2023-10-11 08:11:15 | 6735
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/EXCLUDE_test_lyx.py | 2023-10-09 08:20:29 | 9277
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/matlab_script.m | 2023-10-09 08:20:29 | 84
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/r_script.R | 2023-10-09 08:20:29 | 100
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/move_sources.py | 2023-10-09 08:20:29 | 19397
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Bold.woff | 2023-10-09 08:20:29 | 87624
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_inputs.rst.txt | 2023-10-09 08:20:29 | 99
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato-Bold.ttf | 2023-10-09 08:20:29 | 656544
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/badge_only.js | 2023-10-09 08:20:29 | 934
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-311.pyc | 2023-10-11 08:12:32 | 2598
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_too_many_values.lyx | 2023-10-09 08:20:29 | 4701
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1 2.js | 2023-10-11 08:11:15 | 68420
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/move_sources/gslab_make.move_sources.link_externals.html | 2023-10-11 08:11:15 | 12526
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/move_sources/gslab_make.move_sources.link_externals.rst.txt | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/make_utility/gslab_make.make_utility.update_paths.rst | 2023-10-09 08:20:29 | 102
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_stat_transfer.rst.txt | 2023-10-09 08:20:29 | 116
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.write_to_makelog.doctree | 2023-10-11 08:11:15 | 8103
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/specifying_paths.rst | 2023-10-09 08:20:29 | 2616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging.rst.txt | 2023-10-09 08:20:29 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/write_logs/gslab_make.write_logs.end_makelog.rst.txt | 2023-10-09 08:20:29 | 97
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/move_sources/gslab_make.move_sources.copy_externals.html | 2023-10-11 08:11:15 | 12303
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/__init__.py | 2023-10-09 08:20:29 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_move_sources.py | 2023-10-11 08:11:15 | 7274
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user.yaml | 2023-10-09 08:20:29 | 236
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/movedirective.py | 2023-10-09 08:20:29 | 12767
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/general_logging.html | 2023-10-11 08:11:15 | 14709
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/filling.rst.txt | 2023-10-09 08:20:29 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_sas.doctree | 2023-10-11 08:11:15 | 20509
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-regular.eot | 2023-10-09 08:20:29 | 253461
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/graphviz 2.css | 2023-10-11 08:11:15 | 299
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template_extra_input.lyx | 2023-10-09 08:20:29 | 1736
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/Makefile | 2023-10-09 08:20:29 | 683
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_sas.html | 2023-10-11 08:11:15 | 11821
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.copy_externals.rst | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/SOURCES.txt | 2023-10-11 08:12:24 | 1234
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/fontawesome-webfont 2.eot | 2023-10-11 08:11:15 | 165742
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.2.1.js | 2023-10-11 08:11:15 | 268039
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.13.1.js | 2023-10-09 08:20:29 | 68420
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/tablefill.py | 2023-10-09 08:20:29 | 20325
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_jupyter.doctree | 2023-10-11 08:11:15 | 13990
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.unzip.html | 2023-10-11 08:11:15 | 6701
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/write_logs.cpython-311.pyc | 2023-10-11 08:12:32 | 14353
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/dummy.doctree | 2023-10-11 08:11:15 | 51378
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.doctree | 2023-10-11 08:11:15 | 12579
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_jupyter.rst.txt | 2023-10-09 08:20:29 | 98
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/pygments.css | 2023-10-11 08:11:15 | 4819
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold-italic.woff2 | 2023-10-09 08:20:29 | 193308
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/modify_dir/gslab_make.modify_dir.zip_dir.rst | 2023-10-09 08:20:29 | 85
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_externals.rst | 2023-10-09 08:20:29 | 108
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/recursion.txt | 2023-10-09 08:20:29 | 34
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/jquery-3.5.1 2.js | 2023-10-11 08:11:15 | 287630
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular 2.woff2 | 2023-10-11 08:11:15 | 66444
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_jupyter.html | 2023-10-11 08:11:15 | 10916
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/directory.doctree | 2023-10-11 08:11:15 | 27253
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato-Regular.ttf | 2023-10-09 08:20:29 | 656568
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-bold.eot | 2023-10-09 08:20:29 | 256056
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore-1.12.0 2.js | 2023-10-11 08:11:15 | 67692
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.ttf | 2023-10-09 08:20:29 | 165548
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.execute_command.html | 2023-10-11 08:11:15 | 11312
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_internal_paths.doctree | 2023-10-11 08:11:15 | 8736
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_external_paths.html | 2023-10-11 08:11:15 | 7622
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/underscore-1.3.1.js | 2023-10-09 08:20:29 | 35168
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/tablefill/gslab_make.tablefill.tablefill.rst.txt | 2023-10-09 08:20:29 | 90
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/metadata.cpython-310.pyc | 2023-10-09 08:22:11 | 2192
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir space/file space.txt | 2023-10-09 08:20:29 | 20
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/Lato/lato-bolditalic.woff | 2023-10-09 08:20:29 | 323344
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make.egg-info/top_level.txt | 2023-10-11 08:12:24 | 16
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/filling 2.html | 2023-10-11 08:11:15 | 15857
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-regular.ttf | 2023-10-09 08:20:29 | 607720
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.rst.txt | 2023-10-09 08:20:29 | 124
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/source_logging 2.rst.txt | 2023-10-11 08:11:15 | 380
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy 2.html | 2023-10-11 08:11:15 | 18205
 /Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/check_repo/gslab_make.check_repo.get_modified_sources.html | 2023-10-11 08:11:15 | 8805
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff2 | 2023-10-09 08:20:29 | 184912
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill.txt | 2023-10-09 08:20:29 | 66
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/Lato/lato-italic.eot | 2023-10-09 08:20:29 | 268604
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/search.html | 2023-10-11 08:11:15 | 4762
-/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_perl.py | 2023-10-09 08:20:29 | 8121
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/repository.rst.txt | 2023-10-09 08:20:29 | 363
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/python_script.py | 2023-10-09 08:20:29 | 169
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/WIP_test_matlab.py | 2023-10-09 08:20:29 | 8012
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/source_logging.html | 2023-10-11 08:11:15 | 10644
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/make_utility/gslab_make.make_utility.update_executables.html | 2023-10-11 08:11:15 | 7481
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_r.rst | 2023-10-09 08:20:29 | 80
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments.lyx | 2023-10-09 08:20:29 | 1694
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/sourcing.html | 2023-10-11 08:11:15 | 33056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/make_utility/gslab_make.make_utility.update_external_paths.doctree | 2023-10-11 08:11:15 | 9851
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_python.py | 2023-10-11 08:11:15 | 7056
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/README.md | 2023-10-09 08:20:29 | 1340
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab-Regular.ttf | 2023-10-09 08:20:29 | 169064
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/move_sources/gslab_make.move_sources.link_externals.rst | 2023-10-09 08:20:29 | 108
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_no_tag.txt | 2023-10-09 08:20:29 | 56
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/write_logs/gslab_make.write_logs.log_files_in_output.doctree | 2023-10-11 08:11:15 | 17521
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_comments_comments.lyx.bak | 2023-10-09 08:20:29 | 1694
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/RobotoSlab/roboto-slab-v7-bold.eot | 2023-10-09 08:20:29 | 79520
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/check_repo.cpython-310.pyc | 2023-10-09 08:20:38 | 13639
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/run_program/gslab_make.run_program.run_mathematica.doctree | 2023-10-11 08:11:15 | 18528
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/run_program/gslab_make.run_program.run_module.rst.txt | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/move_sources/gslab_make.move_sources.copy_inputs.doctree | 2023-10-11 08:11:15 | 20928
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/run_program/gslab_make.run_program.run_sas.rst.txt | 2023-10-09 08:20:29 | 86
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/dummy.html | 2023-10-11 08:11:15 | 18203
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/css/fonts/Roboto-Slab-Regular.woff | 2023-10-09 08:20:29 | 86288
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file_beamer.lyx | 2023-10-09 08:20:29 | 2000
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/utility 2.rst.txt | 2023-10-11 08:11:15 | 327
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling.doctree | 2023-10-11 08:11:15 | 28794
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/__pycache__/textfill_info.cpython-310.pyc | 2023-10-09 08:22:12 | 6488
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/js/theme.js | 2023-10-09 08:20:29 | 5023
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/fonts/fontawesome-webfont.svg | 2023-10-09 08:20:29 | 444379
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/lato-bold.woff | 2023-10-09 08:20:29 | 309728
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/write_source_logs/gslab_make.write_source_logs.write_source_logs.rst | 2023-10-09 08:20:29 | 122
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/underscore.js | 2023-10-09 08:20:29 | 19530
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/searchindex.js | 2023-10-11 08:11:15 | 37621
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/modernizr.min.js | 2023-10-09 08:20:29 | 15414
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/filling 2.doctree | 2023-10-11 08:11:15 | 28798
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/test_tablefill.py | 2023-10-11 08:11:15 | 4248
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-regular.eot | 2023-10-09 08:20:29 | 78331
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/tablefill/tablefill_template space.lyx | 2023-10-09 08:20:29 | 4256
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/Roboto-Slab-Bold.woff2 | 2023-10-09 08:20:29 | 67312
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/sourcing 2.html | 2023-10-11 08:11:15 | 31670
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/source_logging.doctree | 2023-10-11 08:11:15 | 20524
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/Makefile | 2023-10-09 08:20:29 | 683
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/fonts/RobotoSlab/roboto-slab-v7-bold.ttf | 2023-10-09 08:20:29 | 170616
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy.rst.txt | 2023-10-09 08:20:29 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/run_program/lyx_file.lyx | 2023-10-09 08:20:29 | 1608
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/utility.py | 2023-10-09 08:20:29 | 1404
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_static/jquery-3.5.1.js | 2023-10-09 08:20:29 | 287630
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.html | 2023-10-11 08:11:15 | 8068
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/genindex.html | 2023-10-11 08:11:15 | 13095
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/directory.rst.txt | 2023-10-09 08:20:29 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/filling.rst | 2023-10-09 08:20:29 | 253
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/api/check_repo/gslab_make.check_repo.check_conda_status.rst.txt | 2023-10-09 08:20:29 | 118
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/__init__.cpython-311.pyc | 2023-10-11 08:12:32 | 183
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/pages/api/run_program/gslab_make.run_program.run_python.html | 2023-10-11 08:11:15 | 11407
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/test/EXCLUDE_test_R.py | 2023-10-11 08:11:15 | 7997
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_perl.html | 2023-10-11 08:11:15 | 11413
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/conf.py | 2023-10-09 08:20:29 | 1537
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/build/lib/gslab_make/make_utility.py | 2023-10-09 08:20:29 | 5785
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/js/html5shiv.min.js | 2023-10-09 08:20:29 | 2734
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/write_logs.py | 2023-10-09 08:20:29 | 10665
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/modify_dir/gslab_make.modify_dir.clear_dir.html | 2023-10-11 08:11:15 | 7869
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/tablefill/gslab_make.tablefill.tablefill.rst | 2023-10-09 08:20:29 | 90
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/pages/api/run_program/gslab_make.run_program.run_mathematica.html | 2023-10-11 08:11:15 | 11436
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/config/config_user_bad.yaml | 2023-10-09 08:20:29 | 131
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/utility.doctree | 2023-10-11 08:11:15 | 28357
+/Users/lawrencechen/Desktop/gentzkow/lib/__init__.py | 2023-10-20 22:14:41 | 0
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_outputs/dir/file.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/subprocess_fix.py | 2023-10-09 08:20:29 | 5428
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/general_logging.rst.txt | 2023-10-09 08:20:29 | 655
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/test/raw/log_sources/dir_depth/dir_depth/depth_2.txt | 2023-10-09 08:20:29 | 20
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/programdirective.cpython-311.pyc | 2023-10-11 08:12:35 | 15605
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/index.doctree | 2023-10-11 08:11:15 | 6021
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/gslab_make/private/__pycache__/movedirective.cpython-310.pyc | 2023-10-09 08:22:11 | 12235
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/doctrees/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.doctree | 2023-10-11 08:11:15 | 10625
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/sphinx_highlight.js | 2023-10-09 08:20:29 | 4712
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/dummy 2.rst.txt | 2023-10-11 08:11:15 | 741
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/build/html/_sources/pages/directory 2.rst.txt | 2023-10-11 08:11:15 | 344
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_sources/pages/api/modify_dir/gslab_make.modify_dir.remove_dir.rst.txt | 2023-10-09 08:20:29 | 94
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/sphinx/source/pages/api/run_program/gslab_make.run_program.run_matlab.rst | 2023-10-09 08:20:29 | 95
+/Users/lawrencechen/Desktop/gentzkow/lib/gslab_make/docs/_static/css/fonts/fontawesome-webfont.eot | 2023-10-09 08:20:29 | 165742

--- a/data/log/versions.log
+++ b/data/log/versions.log
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------
-Versions log started: 2023-10-22 16:42:28
+Versions log started: 2023-10-23 14:05:42
 --------------------------------------------------------------------------------
 # packages in environment at /opt/homebrew/Caskroom/miniconda/base/envs/template:
 #

--- a/data/output/chips_sold.pdf
+++ b/data/output/chips_sold.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:380b51f4f9f93efbf1f874e4f59090a453def8fc59dec5a59052832279fff33f
+oid sha256:5411d85d53bd8cb25ba1bab5be386708f518f615924bdbd54e15859a2ecb4fe2
 size 9940

--- a/paper_slides/input/chips_sold.pdf
+++ b/paper_slides/input/chips_sold.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:380b51f4f9f93efbf1f874e4f59090a453def8fc59dec5a59052832279fff33f
+oid sha256:5411d85d53bd8cb25ba1bab5be386708f518f615924bdbd54e15859a2ecb4fe2
 size 9940

--- a/paper_slides/log/make.log
+++ b/paper_slides/log/make.log
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------
-Makelog started: 2023-10-22 16:44:30
+Makelog started: 2023-10-23 14:05:51
 Working directory: /Users/lawrencechen/Desktop/gentzkow/paper_slides
 --------------------------------------------------------------------------------
 Input copies successfully created!
@@ -7,7 +7,6 @@ External copies successfully created!
 Source logs successfully written!
 WARNING! The following target files have been modified according to git status:
 /Users/lawrencechen/Desktop/gentzkow/data/output/chips_sold.pdf
-/Users/lawrencechen/Desktop/gentzkow/analysis/output/regression.csv
 Version logs successfully written!
 Executing command: `lyx -e pdf2 "/Users/lawrencechen/Desktop/gentzkow/paper_slides/code/paper.lyx"`
 This is pdfTeX, Version 3.141592653-2.6-1.40.24 (TeX Live 2022) (preloaded format=pdflatex)
@@ -53,6 +52,6 @@ L3 programming layer <2022-02-24>
 
 Output logs successfully written!
 --------------------------------------------------------------------------------
-Makelog ended: 2023-10-22 16:44:38
+Makelog ended: 2023-10-23 14:05:58
 Working directory: /Users/lawrencechen/Desktop/gentzkow/paper_slides
 --------------------------------------------------------------------------------

--- a/paper_slides/log/output_stats.log
+++ b/paper_slides/log/output_stats.log
@@ -1,5 +1,5 @@
 file name | last modified | file size
-/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/tables_filled.lyx | 2023-10-22 23:44:32 | 4373
-/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/paper.pdf | 2023-10-22 23:44:34 | 55306
-/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/slides.pdf | 2023-10-22 23:44:38 | 28185
-/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/online_appendix.pdf | 2023-10-22 23:44:36 | 33905
+/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/paper.pdf | 2023-10-23 21:05:55 | 55306
+/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/online_appendix.pdf | 2023-10-23 21:05:56 | 33905
+/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/tables_filled.lyx | 2023-10-23 21:05:53 | 4373
+/Users/lawrencechen/Desktop/gentzkow/paper_slides/output/slides.pdf | 2023-10-23 21:05:59 | 28184

--- a/paper_slides/log/source_stats.log
+++ b/paper_slides/log/source_stats.log
@@ -1,3 +1,3 @@
 file name | last modified | file size
-/Users/lawrencechen/Desktop/gentzkow/data/output/chips_sold.pdf | 2023-10-22 23:42:31 | 9940
-/Users/lawrencechen/Desktop/gentzkow/analysis/output/regression.csv | 2023-10-22 23:17:54 | 58
+/Users/lawrencechen/Desktop/gentzkow/analysis/output/regression.csv | 2023-10-23 21:05:51 | 58
+/Users/lawrencechen/Desktop/gentzkow/data/output/chips_sold.pdf | 2023-10-23 21:05:45 | 9940

--- a/paper_slides/log/versions.log
+++ b/paper_slides/log/versions.log
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------
-Versions log started: 2023-10-22 16:44:32
+Versions log started: 2023-10-23 14:05:52
 --------------------------------------------------------------------------------
 # packages in environment at /opt/homebrew/Caskroom/miniconda/base/envs/template:
 #

--- a/paper_slides/output/online_appendix.pdf
+++ b/paper_slides/output/online_appendix.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b44a7e9984a9865eebd6af226ec7a7e883ff1734f666616e182c242e25edd473
+oid sha256:2f1007d3e6b923d5aececc6aa6df4cf07a9d34661b30d229d8269f1633484873
 size 33905

--- a/paper_slides/output/paper.pdf
+++ b/paper_slides/output/paper.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61c216cf70ba7ec21ca8fe1a196403ec0946449e85b1def529bc18859327416e
+oid sha256:31bb9837a3a0ba2bdd871a088bb8fefeed5ca3147e822cabe36317189490fdf3
 size 55306

--- a/paper_slides/output/slides.pdf
+++ b/paper_slides/output/slides.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8c940b77302e831786a3ce7755315894cfa3392a101c432c429cc4d4f10b81d
-size 28185
+oid sha256:fbd194d8ca6800fd0104adee849085de712835fbb6642c7a350cb71bd679a76b
+size 28184


### PR DESCRIPTION
The goal of the pull request is to modify the code in the data folder ([`~/data/code/clean_data.py`](https://github.com/lawrencech3n/gentzkow/blob/master/data/code/clean_data.py)) so that the histogram in [`~/paper_slides/output/chips_sold.pdf`](https://github.com/lawrencech3n/gentzkow/blob/fe13790124dbe08001d6a88cbc0be28ff72567fc/paper_slides/output/paper.pdf) displays percentages instead of counts. This follows from the [Practice Task Instructions](https://github.com/gslab-econ/lab-manual/wiki/Practice-Task). 